### PR TITLE
Introduce express ensemble loading

### DIFF
--- a/mei/initial.py
+++ b/mei/initial.py
@@ -22,3 +22,22 @@ class RandomNormal(InitialGuessCreator):
 
     def __repr__(self):
         return f"{self.__class__.__qualname__}()"
+
+
+class RandomNormalNullChannel(InitialGuessCreator):
+    """Used to create an initial guess tensor filled with values distributed according to a normal distribution."""
+
+    _create_random_tensor = randn
+
+    def __init__(self, null_channel, null_value=0):
+        self.null_channel = null_channel
+        self.null_value = null_value
+
+    def __call__(self, *shape):
+        """Creates a random initial guess from which to start the MEI optimization process given a shape."""
+        inital = self._create_random_tensor(*shape)
+        inital[:, self.null_channel, ...] = self.null_value
+        return inital
+
+    def __repr__(self):
+        return f"{self.__class__.__qualname__}()"

--- a/mei/methods.py
+++ b/mei/methods.py
@@ -12,9 +12,14 @@ from .import_helpers import import_object
 from .tracking import Tracker
 
 
-def get_input_dimensions(dataloaders, get_dims):
-    dataloaders_dimensions = list(get_dims(dataloaders["train"]).values())
-    return list(dataloaders_dimensions[0].values())[0]
+def get_input_dimensions(dataloaders, get_dims, data_key=None):
+    if data_key is None or data_key not in dataloaders["train"]:
+        dataloaders_dimensions = list(get_dims(dataloaders["train"]).values())
+        return list(dataloaders_dimensions[0].values())[0]
+    else:
+        in_key = "inputs" if "inputs" in dataloaders["train"][data_key] else "images"
+        return get_dims(dataloaders["train"])[data_key][in_key]
+
 
 
 def gradient_ascent(
@@ -88,7 +93,7 @@ def gradient_ascent(
         The MEI, the final evaluation as a single float and the log of the tracker.
     """
     for component_name, component_config in config.items():
-        if component_name in ("device", "objectives"):
+        if component_name in ("device", "objectives", "n_meis", "mei_shape", "model_forward_kwargs"):
             continue
         if "kwargs" not in component_config:
             component_config["kwargs"] = dict()
@@ -103,9 +108,15 @@ def gradient_ascent(
     model.eval()
     model.to(config["device"])
 
-    shape = get_input_dimensions(dataloaders, get_dims)
+    n_meis = config.get("n_meis", 1)
+    model_forward_kwargs = config.get("model_forward_kwargs", dict())
+    model.forward_kwargs.update(model_forward_kwargs)
+
+    data_key = model.forward_kwargs["data_key"]
+    shape = config.get("mei_shape", get_input_dimensions(dataloaders, get_dims, data_key=data_key))
+
     create_initial_guess = import_func(config["initial"]["path"], config["initial"]["kwargs"])
-    initial_guess = create_initial_guess(1, *shape[1:]).to(config["device"])
+    initial_guess = create_initial_guess(n_meis, *shape[1:]).to(config["device"])
 
     optimizer = import_func(config["optimizer"]["path"], dict(params=[initial_guess], **config["optimizer"]["kwargs"]))
     stopper = import_func(config["stopper"]["path"], config["stopper"]["kwargs"])

--- a/mei/mixins.py
+++ b/mei/mixins.py
@@ -204,7 +204,7 @@ class MEITemplateMixin:
         with self.get_temp_dir() as temp_dir:
             for name in ("mei", "output"):
                 self._save_to_disk(mei_entity, temp_dir, name)
-            self.insert1(mei_entity)
+            self.insert1(mei_entity, ignore_extra_fields=True)
 
     def _save_to_disk(self, mei_entity: Dict[str, Any], temp_dir: str, name: str) -> None:
         data = mei_entity.pop(name)

--- a/mei/modules.py
+++ b/mei/modules.py
@@ -49,16 +49,20 @@ class ConstrainedOutputModel(Module):
         model: A PyTorch module.
         constraint: An integer representing the index of a neuron in the model's output. Only the value corresponding
             to that index will be returned.
+        target_fn: Callable, that gets as an input the constrained output of the model.
         forward_kwargs: A dictionary containing keyword arguments that will be passed to the model every time it is
             called. Optional.
     """
 
-    def __init__(self, model: Module, constraint: int, forward_kwargs: Dict[str, Any] = None):
+    def __init__(self, model: Module, constraint: int, target_fn=None, forward_kwargs: Dict[str, Any] = None):
         """Initializes ConstrainedOutputModel."""
         super().__init__()
+        if target_fn is None:
+            target_fn = lambda x: x
         self.model = model
         self.constraint = constraint
         self.forward_kwargs = forward_kwargs if forward_kwargs else dict()
+        self.target_fn = target_fn
 
     def __call__(self, x: Tensor, *args, **kwargs) -> Tensor:
         """Computes the constrained output of the model.
@@ -72,7 +76,7 @@ class ConstrainedOutputModel(Module):
             A tensor representing the constrained output of the model.
         """
         output = self.model(x, *args, **self.forward_kwargs, **kwargs)
-        return output[:, self.constraint]
+        return self.target_fn(output[:, self.constraint])
 
     def __repr__(self):
         return f"{self.__class__.__qualname__}({self.model}, {self.constraint}, forward_kwargs={self.forward_kwargs})"


### PR DESCRIPTION
This PR adds arguments to the `load_model()` function of the ensemble class, such that it is possible to create the ensemble without the dataloader (for express model loading), or without the state dict.
Along with the new defaults of the optimizations module, additional arguments for the iterations are added to the ops module. 