### PR TITLE
make ConstrainedOutputModel compatible with nnvision.utility.measures:model_predictions

### DIFF
--- a/mei/modules.py
+++ b/mei/modules.py
@@ -75,7 +75,11 @@ class ConstrainedOutputModel(Module):
         Returns:
             A tensor representing the constrained output of the model.
         """
-        output = self.model(x, *args, **self.forward_kwargs, **kwargs)
+        duplicate_keys = self.forward_kwargs.keys() & kwargs.keys()
+        reduced_forward_kwargs = self.forward_kwargs
+        for key in duplicate_keys:
+            reduced_forward_kwargs.pop(key)
+        output = self.model(x, *args, **reduced_forward_kwargs, **kwargs)
         return self.target_fn(output[:, self.constraint])
 
     def __repr__(self):


### PR DESCRIPTION
Before, calling model_predicitons to get the predictions of a ConstrainedOutputModel resulted in a bug, as `data_key` was in `self.forward_kwargs` but also in `kwargs`