### PR TITLE
[fix] prevent cached model from being overwritten [add] pass on **kwargs to load_model function

### DIFF
--- a/mei/integration.py
+++ b/mei/integration.py
@@ -1,6 +1,7 @@
 """This module contains classes and functions pertaining to the NNFabrik integration."""
 
 import pickle
+from copy import deepcopy
 
 from nnfabrik.utility.nnf_helper import split_module_name, dynamic_import
 from nnfabrik.utility.dj_helpers import make_hash
@@ -36,7 +37,7 @@ class ModelLoader:
             return self._load_model(key)
         if not self._is_cached(key):
             self._cache_model(key)
-        return self._get_cached_model(key)
+        return deepcopy(self._get_cached_model(key))
 
     def _load_model(self, key):
         return self.model_table().load_model(key=key)

--- a/mei/integration.py
+++ b/mei/integration.py
@@ -32,24 +32,24 @@ class ModelLoader:
         self.cache_size_limit = cache_size_limit
         self.cache = dict()
 
-    def load(self, key):
+    def load(self, key, **kwargs):
         if self.cache_size_limit == 0:
-            return self._load_model(key)
+            return self._load_model(key, **kwargs)
         if not self._is_cached(key):
-            self._cache_model(key)
+            self._cache_model(key, **kwargs)
         return deepcopy(self._get_cached_model(key))
 
-    def _load_model(self, key):
-        return self.model_table().load_model(key=key)
+    def _load_model(self, key, **kwargs):
+        return self.model_table().load_model(key=key, **kwargs)
 
     def _is_cached(self, key):
         if self._hash_trained_model_key(key) in self.cache:
             return True
         return False
 
-    def _cache_model(self, key):
+    def _cache_model(self, key, **kwargs):
         """Caches a model and makes sure the cache is not bigger than the specified limit."""
-        self.cache[self._hash_trained_model_key(key)] = self._load_model(key)
+        self.cache[self._hash_trained_model_key(key)] = self._load_model(key, **kwargs)
         if len(self.cache) > self.cache_size_limit:
             del self.cache[list(self.cache)[0]]
 


### PR DESCRIPTION
This PR makes the cached ModelLoader more robust preventing cached models from accidentally being overwritten. This is achieved by always returning a deepcopy instead of a reference to the cached model.