### PR TITLE
Fix/dj pipe and improvements

### DIFF
--- a/demo/dj_integration.ipynb
+++ b/demo/dj_integration.ipynb
@@ -33,7 +33,7 @@
     "from torch import load\n",
     "\n",
     "from mei.main import TrainedEnsembleModelTemplate, CSRFV1SelectorTemplate, MEISeed, MEIMethod, MEITemplate\n",
-    "from nnfabrik.template import TrainedModelBase\n",
+    "from nnfabrik.templates import TrainedModelBase\n",
     "from nnfabrik.main import Dataset"
    ]
   },
@@ -246,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/mei/main.py
+++ b/mei/main.py
@@ -7,7 +7,7 @@ of the regular DataJoint schema with the templates in this module.
 import datajoint as dj
 from nnfabrik.main import Dataset, schema
 
-from . import mixins
+from . import integration, mixins
 
 
 class TrainedEnsembleModelTemplate(mixins.TrainedEnsembleModelTemplateMixin, dj.Manual):
@@ -48,7 +48,7 @@ class MEIMethod(mixins.MEIMethodMixin, dj.Lookup):
     """Table that contains MEI methods and their configurations."""
 
 
-class MEITemplate(mixins.MEITemplateMixin, dj.Computed):
+class MEITemplate(mixins.MEIMixin, dj.Computed):
     """MEI table template.
 
     To create a functional "MEI" table, create a new class that inherits from this template and decorate it with your
@@ -60,3 +60,15 @@ class MEITemplate(mixins.MEITemplateMixin, dj.Computed):
 
     method_table = MEIMethod
     seed_table = MEISeed
+
+
+class CSRFV1SelectorTemplate(mixins.CSRFV1SelectorTemplateMixin, dj.Computed):
+    """CSRF V1 selector table template.
+
+    To create a functional "CSRFV1Selector" table, create a new class that inherits from this template and decorate it
+    with your preferred Datajoint schema. By default, the created table will point to the "Dataset" table in the
+    Datajoint schema called "nnfabrik.main". This behavior can be changed by overwriting the class attribute called
+    "dataset_table".
+    """
+
+    dataset_table = Dataset

--- a/mei/mixins.py
+++ b/mei/mixins.py
@@ -191,7 +191,7 @@ class MEIMethodMixin:
         self.insert_key_in_ops(method_config=method_config, key=key)
 
         train_input_shape = next(iter(next(iter(dataloaders["train"].values())))).images.shape
-        input_shape = (1, 4) + train_input_shape[2:]
+        input_shape = (1,) + train_input_shape[1:]
         mei, score, output = method_fn(model=model, config=method_config, seed=seed, shape=input_shape)
 
         return dict(key, mei=mei, score=score, output=output)

--- a/mei/postprocessing.py
+++ b/mei/postprocessing.py
@@ -81,7 +81,9 @@ class PNormConstraintAndClip:
 
     def __call__(self, img: torch.Tensor, iteration=None):
         normalized_img = self.p_norm_constraint(img, iteration)
-        normalized_img = torch.where(normalized_img > self.max_pixel_value, self.max_pixel_value, normalized_img)
-        normalized_img = torch.where(normalized_img < self.min_pixel_value, self.min_pixel_value, normalized_img)
+        max_pixel_value = torch.tensor(self.max_pixel_value, dtype=normalized_img.dtype, device=normalized_img.device)
+        min_pixel_value = torch.tensor(self.min_pixel_value, dtype=normalized_img.dtype, device=normalized_img.device)
+        normalized_img = torch.where(normalized_img > max_pixel_value, max_pixel_value, normalized_img)
+        normalized_img = torch.where(normalized_img < min_pixel_value, min_pixel_value, normalized_img)
 
         return normalized_img

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ datajoint<=0.12.9
 nnfabrik
 torch
 scipy>=1.7.0,<=1.12.0
-numpy>=1.22.0,<=1.26.4
+numpy>=1.21.0,<=1.26.4
 torchvision
 pytest


### PR DESCRIPTION
Hi @PPierzc @Mvystrcilova , I just checked the datajoint demo notebook, and there were some bugs in the DJ pipeline that prevented executing it. I fixed those bugs, improved a naming convention for `MEIMixin` and added `**kwargs` that forward to `dj.insert` and to `.load_model` (the latter is required for the same functionality that was introduced for the model cache here https://github.com/sinzlab/mei/pull/17 ). I am not sure about the `CSRFV1Selector` table: this table is required, but was not implemented. I implemented it similar as how it was done in `nndichromacy` and tested that it works with the mouse sensorium 2022 images data.

This PR also includes the already approved and not yet merged PR https://github.com/sinzlab/mei/pull/37 